### PR TITLE
Review fixes

### DIFF
--- a/code/bootstrap/pom.xml
+++ b/code/bootstrap/pom.xml
@@ -19,19 +19,6 @@
 
     <dependencies>
         <dependency>
-            <groupId>io.helidon.integrations.langchain4j</groupId>
-            <artifactId>helidon-integrations-langchain4j</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.helidon.integrations.langchain4j.providers</groupId>
-            <artifactId>helidon-integrations-langchain4j-providers-open-ai</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>dev.langchain4j</groupId>
-            <artifactId>langchain4j-embeddings-all-minilm-l6-v2</artifactId>
-            <version>${version.lib.langchain4j}</version>
-        </dependency>
-        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-jdk14</artifactId>
             <scope>runtime</scope>
@@ -65,29 +52,6 @@
                         <id>copy-libs</id>
                     </execution>
                 </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <annotationProcessorPaths>
-                        <path>
-                            <groupId>io.helidon.codegen</groupId>
-                            <artifactId>helidon-codegen-apt</artifactId>
-                            <version>${helidon.version}</version>
-                        </path>
-                        <path>
-                            <groupId>io.helidon.integrations.langchain4j</groupId>
-                            <artifactId>helidon-integrations-langchain4j-codegen</artifactId>
-                            <version>${helidon.version}</version>
-                        </path>
-                        <path>
-                            <groupId>io.helidon.service</groupId>
-                            <artifactId>helidon-service-codegen</artifactId>
-                            <version>${helidon.version}</version>
-                        </path>
-                    </annotationProcessorPaths>
-                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/hol/03_enabling_ai_capabilities_in_the_project.md
+++ b/hol/03_enabling_ai_capabilities_in_the_project.md
@@ -116,8 +116,10 @@ After adding the configuration, the chat model will be **available for injection
 Update `ChatBotService.java` as follows:
 
 ```java
+import dev.langchain4j.model.chat.ChatLanguageModel;
+
 @Service.Singleton
-class ChatBotService implements HttpService {
+public class ChatBotService implements HttpService {
 
     private final ChatLanguageModel chatModel;
 

--- a/hol/04_building_ai_service.md
+++ b/hol/04_building_ai_service.md
@@ -30,7 +30,7 @@ At this stage, only the **`ChatLanguageModel`** has been configured, so it will 
 
 📌 We will keep all AI-related classes in `io.helidon.hol.lc4j.ai` package. Create this package first if it doesn't exist.
 
-**Create a new file `MenuItem.java` in `io.helidon.hol.lc4j.ai` package:**
+**Create a new file `ChatAiService.java` in `io.helidon.hol.lc4j.ai` package:**
 
 ```java
 package io.helidon.hol.lc4j.ai;
@@ -40,7 +40,7 @@ import io.helidon.integrations.langchain4j.Ai;
 import dev.langchain4j.service.SystemMessage;
 
 @Ai.Service
-interface ChatAiService {
+public interface ChatAiService {
 
     String chat(String question);
 }
@@ -70,7 +70,7 @@ Here is the updated version of `ChatBotService`:
 
 ```java
 @Service.Singleton
-class ChatBotService implements HttpService {
+public class ChatBotService implements HttpService {
 
     private final ChatAiService chatAiService;
 

--- a/hol/05_adding_rag.md
+++ b/hol/05_adding_rag.md
@@ -101,11 +101,7 @@ To connect our embedding store to the **AI Service**, we need a **Content Retrie
 
 ```yaml
 langchain4j:
-  open-ai:
-    chat-model:
-      enabled: true
-      api-key: "demo"
-      model-name: "gpt-4o-mini"
+  ...
   rag:
     embedding-store-content-retriever:
       enabled: true

--- a/hol/05_adding_rag.md
+++ b/hol/05_adding_rag.md
@@ -10,7 +10,7 @@
 
 ## 1. What is RAG?
 
-**Retrieval-Augmented Generation (RAG)** is an advanced AI technique that enhances LLMs (Large Language Models) by allowing them to retrieve **external knowledge** in real-time. Instead of relying solely on pre-trained data, RAG enables AI models to fetch relevant information from external sources, such as knowledge bases, document stores, or embeddings storage**, leading to more accurate, context-aware responses.
+**Retrieval-Augmented Generation (RAG)** is an advanced AI technique that enhances LLMs (Large Language Models) by allowing them to retrieve **external knowledge** in real-time. Instead of relying solely on pre-trained data, RAG enables AI models to fetch relevant information from external sources, such as knowledge bases, document stores, or **embeddings storage**, leading to more accurate, context-aware responses.
 
 ### Key Components of RAG:
 
@@ -42,7 +42,7 @@ We will use the `AllMiniLmL6V2EmbeddingModel`, a pretrained embedding model from
 package io.helidon.hol.lc4j.ai;
 
 import java.util.function.Supplier;
-import dev.langchain4j.model.embedding.AllMiniLmL6V2EmbeddingModel;
+import dev.langchain4j.model.embedding.onnx.allminilml6v2.AllMiniLmL6V2EmbeddingModel;
 import dev.langchain4j.model.embedding.EmbeddingModel;
 import io.helidon.service.registry.Service;
 
@@ -97,10 +97,15 @@ class EmbeddingStoreFactory implements Supplier<EmbeddingStore<TextSegment>> {
 
 To connect our embedding store to the **AI Service**, we need a **Content Retriever**. Instead of writing Java code, Helidon allows configuring it directly via YAML.
 
-**Modify `application.yaml` and add the following:**
+**Modify `application.yaml` and add the RAG configuration part:**
 
 ```yaml
 langchain4j:
+  open-ai:
+    chat-model:
+      enabled: true
+      api-key: "demo"
+      model-name: "gpt-4o-mini"
   rag:
     embedding-store-content-retriever:
       enabled: true
@@ -146,7 +151,7 @@ http://localhost:8080/chat?question=What drinks do you have?
 Or use `curl`:
 
 ```sh
-curl -X GET "http://localhost:8080/chat?question=What drinks do you have?"
+curl -G -X GET "http://localhost:8080/chat" --data-urlencode "question=What drinks do you have?"
 ```
 
 **Expected Behavior:**


### PR DESCRIPTION
- java 24 release date is 18 March
- java 24 ea prints warnings during build
```
WARNING: A restricted method in java.lang.System has been called
WARNING: java.lang.System::load has been called by org.fusesource.jansi.internal.JansiLoader in an unnamed module (file:/home/daniel/.sdkman/candidates/maven/current/lib/jansi-2.4.1.jar)
WARNING: Use --enable-native-access=ALL-UNNAMED to avoid a warning for callers in this module
WARNING: Restricted methods will be blocked in a future release unless native access is enabled

WARNING: A terminally deprecated method in sun.misc.Unsafe has been called
WARNING: sun.misc.Unsafe::objectFieldOffset has been called by com.google.common.util.concurrent.AbstractFuture$UnsafeAtomicHelper (file:/home/daniel/.sdkman/candidates/maven/current/lib/guava-33.2.1-jre.jar)
WARNING: Please consider reporting this to the maintainers of class com.google.common.util.concurrent.AbstractFuture$UnsafeAtomicHelper
WARNING: sun.misc.Unsafe::objectFieldOffset will be removed in a future release
```


3.2 - dependecies already in the pom
3.3 - ChatLanguageModel import is hard to resolve(intellij gets confused), import of fqdn would be better dev.langchain4j.model.chat.ChatLanguageModel
3.3 - ChatBotService can't be accessed from ApplicationMain when package private
4.2 - MenuItem or ChatAiService
4.2 - ChatAiService needs to be public
4.3 - ChatBotService can't be accessed from ApplicationMain when package private
5.1 - embeddings storage** non-paired bold
5.2 - Bad package for emb. model, should be: import dev.langchain4j.model.embedding.onnx.allminilml6v2.AllMiniLmL6V2EmbeddingModel;


- Again getting Java 24 warnings this time at app startup:
```
WARNING: A restricted method in java.lang.System has been called
WARNING: java.lang.System::load has been called by ai.onnxruntime.OnnxRuntime in an unnamed module (file:/home/daniel/idp/ora/helidon/helidon-ai-hol/code/bootstrap/target/libs/onnxruntime-1.17.1.jar)
WARNING: Use --enable-native-access=ALL-UNNAMED to avoid a warning for callers in this module
WARNING: Restricted methods will be blocked in a future release unless native access is enabled
```


5.3 - Modify config is not exact about adding rag yaml part, when cleanly replaced and omitting open-ai brach, following error happens:
```
2025.02.17 15:12:52 INFO ai.djl.util.Platform Thread[#3,main,5,main]: Found matching platform from: jar:file:/home/daniel/idp/ora/helidon/helidon-ai-hol/code/bootstrap/target/libs/tokenizers-0.28.0.jar!/native/lib/tokenizers.properties
2025.02.17 15:12:52 INFO ai.djl.huggingface.tokenizers.jni.LibUtils Thread[#3,main,5,main]: Extracting native/lib/linux-x86_64/libtokenizers.so to cache ...
Exception in thread "main" dev.langchain4j.exception.IllegalConfigurationException: Please specify either chatLanguageModel or streamingChatLanguageModel
        at dev.langchain4j.exception.IllegalConfigurationException.illegalConfiguration(IllegalConfigurationException.java:12)
        at dev.langchain4j.service.AiServices.performBasicValidation(AiServices.java:461)
        at dev.langchain4j.service.DefaultAiServices.build(DefaultAiServices.java:94)
        at io.helidon.hol.lc4j.ai.ChatAiService__AiService.get(ChatAiService__AiService.java: 
```

5.5 - Malformed Curl url, shoul be:
`curl -G -X GET "http://localhost:8080/chat" --data-urlencode "question=What drinks do you have?"`